### PR TITLE
[СберБанк-ru] remove 0321 [СберБизнес-ru] sender

### DIFF
--- a/src/СберБанк-ru_4624/senders.txt
+++ b/src/СберБанк-ru_4624/senders.txt
@@ -1,9 +1,3 @@
 900
-9000
-9001
-8632
-6470
 SBERBANK
-90-0
 ru.sberbankmobile
-+7900

--- a/src/СберБанк-ru_4624/senders.txt
+++ b/src/СберБанк-ru_4624/senders.txt
@@ -6,5 +6,4 @@
 SBERBANK
 90-0
 ru.sberbankmobile
-0321
 +7900


### PR DESCRIPTION
Выгляди, что 0321 попал в отправители обычного (не бизнес) Сбера по ошибке (или если и использовался, то давно)