### PR TITLE
[Приорбанк-by] update formats Oplata and Perevod (поддержка варианта с Balance:)

### DIFF
--- a/src/Приорбанк-by_15353/formats/Priorbank Karta Oplata BYN NLD UBER BY MAR WQAS HE_2921.txt
+++ b/src/Приорбанк-by_15353/formats/Priorbank Karta Oplata BYN NLD UBER BY MAR WQAS HE_2921.txt
@@ -1,7 +1,10 @@
-^.*?\*(\d{4}).* ([\d-]{8}) .*plata (?!.*ostup)([\d\s.,]*\d)\s*([A-Z]{3})\.?\s+(.*?)\..*
+^.*?\*(\d{4}).* ([\d-]{8}) .*plata (?!.*ostup)([\d\s.,]*\d)\s*([A-Z]{3})\.?\s+(.*?)\.(?:.*?Balance:\s*([\d\s.,]*\d)\s*([A-Z]{3}))?.*
 
 -----COLUMNS-----
-syncid;date#dd-MM-yy;outcome;instrument;payee
+syncid;date#dd-MM-yy;outcome;instrument;payee;av_balance;acc_instrument
 
 -----EXAMPLE-----
 Priorbank. Karta 4***9602. 30-03-17 17:59:06. Oplata 4.17 BYN. NLD UBER BY MAR30 2WQAS HELP..  Spravka: 80172899292
+
+-----EXAMPLE-----
+Karta 4***5038 10-05-26 14:54:44. Oplata 117.90 BYN. BLR AZS N2. Balance: 337.79 BYN. Tel. 7299090

--- a/src/Приорбанк-by_15353/formats/Priorbank Karta Perevod BYN BLR P P SDBO Spravka_2924.txt
+++ b/src/Приорбанк-by_15353/formats/Priorbank Karta Perevod BYN BLR P P SDBO Spravka_2924.txt
@@ -1,7 +1,10 @@
-^.*?\*(\d{4}).* ([\d-]{8}) .*erevod(?!.*ostup)([\d\s.,]*\d)\s*([A-Z]{3}).*
+^.*?\*(\d{4}).* ([\d-]{8}) .*erevod(?!.*ostup)([\d\s.,]*\d)\s*([A-Z]{3})(?:\.?\s+(.*?)\.)?(?:.*?Balance:\s*([\d\s.,]*\d)\s*([A-Z]{3}))?.*
 
 -----COLUMNS-----
-syncid;date#dd-MM-yy;outcome;instrument
+syncid;date#dd-MM-yy;outcome;instrument;payee;av_balance;acc_instrument
 
 -----EXAMPLE-----
 Priorbank. Karta 4***1991. 04-04-17 11:43:34. Perevod 9.40 BYN. BLR P2P_SDBO.  Spravka: 80172899292
+
+-----EXAMPLE-----
+Karta 4***6259 11-05-26 10:51:32. Perevod 8977.50 BYN. BLR P2P SDBO NO FEE. Balance: 1915.40 BYN. Tel. 7299090


### PR DESCRIPTION
Расширил два существующих формата Приорбанка, чтобы они захватывали баланс из новой разновидности SMS (поле `Balance:` вместо `Dostupno:`/`Spravka:`, и без префикса `Priorbank.`).

### Изменено

- `Priorbank Karta Oplata BYN NLD UBER BY MAR WQAS HE_2921.txt`
    - Регексп: добавлен опциональный хвост `(?:.*?Balance:\s*([\d\s.,]*\d)\s*([A-Z]{3}))?`.
    - Колонки: было `syncid;date#dd-MM-yy;outcome;instrument;payee` → стало `…;av_balance;acc_instrument`.
- `Priorbank Karta Perevod BYN BLR P P SDBO Spravka_2924.txt`
    - Регексп: добавлен опциональный `payee` (раньше не извлекался) и тот же опциональный хвост с `Balance:`.
    - Колонки: было `syncid;date#dd-MM-yy;outcome;instrument` → стало `…;payee;av_balance;acc_instrument`.

### Новые примеры

```
Karta 4***5038 10-05-26 14:54:44. Oplata 117.90 BYN. BLR AZS N2. Balance: 337.79 BYN. Tel. 7299090
Karta 4***6259 11-05-26 10:51:32. Perevod 8977.50 BYN. BLR P2P SDBO NO FEE. Balance: 1915.40 BYN. Tel. 7299090
```

### Проверки

- Старые примеры продолжают матчиться: опциональные группы дают `None`, итоговое количество групп = количеству колонок.
- `python3 scripts/validate.py` → `Validation OK` (cross-match включён).
- Соседние Priorbank-форматы не задеты: они либо требуют `Dostupno` в SMS (`_2235`, `_2666`, `_3699`, `_4926`), либо ждут 10-символьную дату (`_3696`, `_3699`, `_3725`) — наши новые примеры под эти условия не подходят.