### PR TITLE
[Bank of Georgia-ge] Fix bug in formats Purchase Card:***1234

### DIFF
--- a/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
@@ -1,4 +1,4 @@
-Purchase:\s*([A-Za-z]{1,4})([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(?:You will get:|Balance:).+(\d{2}\.\d{2}\.\d{4})\s*$
+Purchase:\s*([A-Za-z]{1,4})\s*([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)(?:\s+(?:You will get:|Balance:|Remaining balance:).+)?\s+(\d{2}\.\d{2}\.\d{4})\s*$
 
 -----COLUMNS-----
 instrument;outcome;syncid;payee;av_balance;date#dMy

--- a/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
@@ -1,7 +1,7 @@
-Purchase:\s*([A-Za-z]{1,4})([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(\d{2}\.\d{2}\.\d{4})\s*$
+Purchase:\s*([A-Za-z]{1,4})([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(?:You will get:|Balance:\s*[A-Za-z]{0,3}([\d.,]+)).+(\d{2}\.\d{2}\.\d{4})\s*$
 
 -----COLUMNS-----
-instrument;outcome;syncid;payee;date#dMy
+instrument;outcome;syncid;payee;av_balance;date#dMy
 
 -----EXAMPLE-----
 Purchase: GEL18.59 Card:***5506 SAMASAMA You will get: 32.53 PLUS Total: 24,481.97 PLUS 14.07.2025
@@ -17,3 +17,9 @@ Purchase: GEL77.11 Card:***5506 Europroduct Get ready for PLUS Birthday You will
 
 -----EXAMPLE-----
 Purchase: GEL77.64 Card:***3974 Wolt Get ready for PLUS Birthday Balance: GEL1,888.80, USD1,010.00, EUR883.31, GBP9,600.00 You will get: 174.69 PLUS Total: 27,607.79 PLUS 20.06.2025
+
+-----EXAMPLE-----
+Purchase: GEL49.99 Card:***1234 Zoomart Givi Kartozia str 6 Balance: GEL672.44 you received: 87.48 PLUS Total: 17,142.25 PLUS 20.05.2026
+
+-----EXAMPLE-----
+Purchase: GEL20.25 Card:***1234 I/E GEOGI BRIA Balance: GEL722.43 you received: 35.44 PLUS Total: 17,054.77 PLUS 18.05.2026

--- a/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
@@ -1,4 +1,4 @@
-Purchase:\s*([A-Za-z]{1,4})\s*([\d.,]+)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(?:(?:You will get:|(?:Remaining )?[Bb]alance:\s*(?:[A-Za-z]{1,4}\s*)?([\d.,]+)(?:\s*[A-Za-z]{1,4})?).*\s)?(\d{2}\.\d{2}\.\d{4})\s*$
+Purchase:\s*([A-Za-z]{1,4})([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(?:You will get:|Balance:).+(\d{2}\.\d{2}\.\d{4})\s*$
 
 -----COLUMNS-----
 instrument;outcome;syncid;payee;av_balance;date#dMy

--- a/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
@@ -1,7 +1,7 @@
 Purchase:\s*([A-Za-z]{1,4})\s*([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)(?:\s+(?:You will get:|Balance:|Remaining balance:).+)?\s+(\d{2}\.\d{2}\.\d{4})\s*$
 
 -----COLUMNS-----
-instrument;outcome;syncid;payee;av_balance;date#dMy
+instrument;outcome;syncid;payee;date#dMy
 
 -----EXAMPLE-----
 Purchase: GEL18.59 Card:***5506 SAMASAMA You will get: 32.53 PLUS Total: 24,481.97 PLUS 14.07.2025

--- a/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
@@ -1,4 +1,4 @@
-Purchase:\s*([A-Za-z]{1,4})([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(?:You will get:|Balance:\s*[A-Za-z]{0,3}([\d.,]+)).+(\d{2}\.\d{2}\.\d{4})\s*$
+Purchase:\s*([A-Za-z]{1,4})\s*([\d.,]+)\s+Card:\s*\*+(\d{4})\s+(.+?)\s+(?:(?:You will get:|(?:Remaining )?[Bb]alance:\s*(?:[A-Za-z]{1,4}\s*)?([\d.,]+)(?:\s*[A-Za-z]{1,4})?).*\s)?(\d{2}\.\d{2}\.\d{4})\s*$
 
 -----COLUMNS-----
 instrument;outcome;syncid;payee;av_balance;date#dMy


### PR DESCRIPTION
Для последнего варианта Card:***1234(где после card нет пробела и 3 звездочка исправил баг где в названия получателя (payee) попадал весь мусор в виде бонусных балов. Кроме этого еще внес туда Доступный баланс если есть.  Добавил примеры:
```
Purchase: GEL49.99 Card:***1234 Zoomart Givi Kartozia str 6 Balance: GEL672.44 you received: 87.48 PLUS Total: 17,142.25 PLUS 20.05.2026
Purchase: GEL20.25 Card:***1234 I/E GEOGI BRIA Balance: GEL722.43 you received: 35.44 PLUS Total: 17,054.77 PLUS 18.05.2026
```