### PR TITLE
[Zur Kantonalbank] support charge, reservation and refund SMS

### DIFF
--- a/src/Zürcher Kantonalbank-ch_16048/formats/online zkb ch Your card has been charged CHF Purch_6093.txt
+++ b/src/Zürcher Kantonalbank-ch_16048/formats/online zkb ch Your card has been charged CHF Purch_6093.txt
@@ -1,4 +1,4 @@
-^.*charged\s+([A-Z]{3}|\W)\s*([\d\s.,']*\d).*urcha.*x{4}\s*(\d{4}),\s+(.*?)\s*\.?$
+^.*charged\s+([A-Z]{3}|\W)\s*([\d\s.,']*\d)\s+.*?Visa\s+Debit\s+card\s+No\.\s*x{4}\s*(\d{4})(?:,\s+(.*?)(?:\s+PENDING)?)?\s*\.?\s*$
 
 -----COLUMNS-----
 instrument;outcome;syncid;payee
@@ -8,3 +8,12 @@ online@zkb.ch Your card has been charged CHF 22.52 Purchase ZKB Visa Debit card 
 
 -----EXAMPLE-----
 online@zkb.ch Your card has been charged CHF 27.00 Online purchase with ZKB Visa Debit card No. xxxx 5387, SBB CFF FFS.
+
+-----EXAMPLE-----
+online@zkb.ch Your card has been charged CHF 22.50 Purchase ZKB Visa Debit card No. xxxx 5387.
+
+-----EXAMPLE-----
+online@zkb.ch Your card has been charged CHF 86.32 Reservation ZKB Visa Debit card No. xxxx 5387, UBER   * EATS PENDING  .
+
+-----EXAMPLE-----
+online@zkb.ch Your card has been charged CHF 440.00 Online purchase with ZKB Visa Debit card No. xxxx 5387.

--- a/src/Zürcher Kantonalbank-ch_16048/formats/online zkb ch Your card has been credited CHF Refu_.txt
+++ b/src/Zürcher Kantonalbank-ch_16048/formats/online zkb ch Your card has been credited CHF Refu_.txt
@@ -1,0 +1,7 @@
+^.*credited\s+([A-Z]{3}|\W)\s*([\d\s.,']*\d)\s+.*?Visa\s+Debit\s+card\s+no\.\s*x{4}\s*(\d{4})(?:,\s+(.*?))?\s*\.?\s*$
+
+-----COLUMNS-----
+instrument;income;syncid;payee
+
+-----EXAMPLE-----
+online@zkb.ch Your card has been credited CHF 32.70 Refund ZKB Visa Debit card no. xxxx 5387, digitec Galaxus (Online).


### PR DESCRIPTION
More ZKB card SMS variants from my own inbox:
charged SMS with Reservation wording or without a merchant name at the end weren't matched — generalized the existing format
added a new format for credited ... Refund messages, parsed as income
the PENDING status suffix on reservations is cut from the payee
scripts/validate.py passes.