### PR TITLE
[Bank of Georgia-ge] update format Purchase GEL Card SAMASAMA You will get PLUS Total

### DIFF
--- a/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Purchase GEL Card SAMASAMA You will get PLUS Total_9219.txt
@@ -1,4 +1,4 @@
-Purchase:\s*([A-Za-z]{1,4})\s*([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)(?:\s+(?:You will get:|Balance:|Remaining balance:).+)?\s+(\d{2}\.\d{2}\.\d{4})\s*$
+Purchase:\s*([A-Za-z]{1,4})\s*([\d\s.,]+?)\s+Card:\s*\*+(\d{4})\s+(.+?)(?:\s+(?:You will get:|Balance:|Remaining balance:|you received:).+)?\s+(\d{2}\.\d{2}\.\d{4})\s*$
 
 -----COLUMNS-----
 instrument;outcome;syncid;payee;date#dMy
@@ -23,3 +23,27 @@ Purchase: GEL49.99 Card:***1234 Zoomart Givi Kartozia str 6 Balance: GEL672.44 y
 
 -----EXAMPLE-----
 Purchase: GEL20.25 Card:***1234 I/E GEOGI BRIA Balance: GEL722.43 you received: 35.44 PLUS Total: 17,054.77 PLUS 18.05.2026
+
+-----EXAMPLE-----
+Purchase: GEL12.90
+Card:***8295
+BOLT TAXI
+you received: 29.03 PLUS
+Total: 43,349.47 PLUS
+01.08.2026
+
+-----EXAMPLE-----
+Purchase: GEL14.00
+Card:***0833
+Chika Rustaveli
+you received: 31.50 PLUS
+Total: 43,320.45 PLUS
+31.07.2026
+
+-----EXAMPLE-----
+Purchase: GEL27.00
+Card:***0833
+808
+you received: 60.75 PLUS
+Total: 43,288.95 PLUS
+31.07.2026


### PR DESCRIPTION
## Summary
- Fix payee extraction for Bank of Georgia "Purchase" SMS that contain a "you received: X PLUS" line without a preceding "Balance:"/"You will get:"/"Remaining balance:" line — previously the whole tail (payee + PLUS bonus text) was captured into `payee`.
- Added `you received:` to the list of trigger phrases that cut off the payee group, alongside the existing `You will get:`, `Balance:`, `Remaining balance:`.

## Test plan
- [x] `python3 scripts/validate.py` passes locally.
- [x] All 7 pre-existing examples still match with identical captured groups (no regression).
- [x] 3 new examples added, payee now correctly resolves to `BOLT TAXI`, `Chika Rustaveli`, `808` instead of swallowing the trailing PLUS bonus text.