### PR TITLE
[TBC Bank-ge] split format back into with/without cashback comment

### DIFF
--- a/src/TBC Bank-ge_15622/formats/GEL BoltTaxi Balance GEL You ve received GEL In Er_11671.txt
+++ b/src/TBC Bank-ge_15622/formats/GEL BoltTaxi Balance GEL You ve received GEL In Er_11671.txt
@@ -1,4 +1,4 @@
-^(\d[\d\s.,]*[.,]\d{2})(\S+)\s+\(\*(\d{4})\)\s+((?:(?!Balance:|Nashti:).)+?)\s+(?:(?:Balance:|Nashti:)\s*(-?\d[\d\s.,]*[.,]\d{2})\s*(\S+))?\s*((?:You.?ve|You have)? received:(?:(?!\d{2}\/\d{2}\/\d{2}).)*)?\s*(\d{2}\/\d{2}\/\d{2})
+(\d[\d\s.,]*[.,]\d{2})(\S+)\s+\(\*(\d{4})\)\s+(.+?)\s+(?:Balance:|Nashti:)\s*(-?\d[\d\s.,]*[.,]\d{2})(\S+)\s+((?:You.?ve|You have) received:.*?)\s+(\d{2}\/\d{2}\/\d{2})
 
 -----COLUMNS-----
 outcome;instrument;syncid;payee;balance;acc_instrument;comment;date#dMy
@@ -8,9 +8,3 @@ outcome;instrument;syncid;payee;balance;acc_instrument;comment;date#dMy
 
 -----EXAMPLE-----
 190.00GEL (*8089) RPM LLC Balance: 902.60GEL  You have received: 1.33GEL In Ertguli Piggy bank you have: 10.67GEL 10/07/26 19:21
-
------EXAMPLE-----
-34.20GEL (*9655) CARREFOUR Nashti: 18850.72GEL    11/06/26 21:33
-
------EXAMPLE-----
-15.70GEL (*5364) MOZAIKA Balance: 8256.74GEL    11/06/26 16:52

--- a/src/TBC Bank-ge_15622/formats/GEL BoltTaxi Balance GEL You ve received GEL In Er_11671.txt
+++ b/src/TBC Bank-ge_15622/formats/GEL BoltTaxi Balance GEL You ve received GEL In Er_11671.txt
@@ -1,7 +1,7 @@
 (\d[\d\s.,]*[.,]\d{2})(\S+)\s+\(\*(\d{4})\)\s+(.+?)\s+(?:Balance:|Nashti:)\s*(-?\d[\d\s.,]*[.,]\d{2})(\S+)\s+((?:You.?ve|You have) received:.*?)\s+(\d{2}\/\d{2}\/\d{2})
 
 -----COLUMNS-----
-outcome;instrument;syncid;payee;balance;acc_instrument;comment;date#dMy
+outcome;instrument;syncid;payee;av_balance;acc_instrument;comment;date#dMy
 
 -----EXAMPLE-----
 10.00GEL (*8089) BoltTaxi Balance: 1792.44GEL  You’ve received: 0.07GEL In Ertguli Piggy bank you have: 25.98GEL 12/06/26 11:59

--- a/src/TBC Bank-ge_15622/formats/GEL CARREFOUR Nashti GEL.txt
+++ b/src/TBC Bank-ge_15622/formats/GEL CARREFOUR Nashti GEL.txt
@@ -1,7 +1,7 @@
 (\d[\d\s.,]*[.,]\d{2})(\S+)\s+\(\*(\d{4})\)\s+(.+?)\s+(?:Balance:|Nashti:)\s*(-?\d[\d\s.,]*[.,]\d{2})(\S+)\s+(\d{2}\/\d{2}\/\d{2})
 
 -----COLUMNS-----
-outcome;instrument;syncid;payee;balance;acc_instrument;date#dMy
+outcome;instrument;syncid;payee;av_balance;acc_instrument;date#dMy
 
 -----EXAMPLE-----
 34.20GEL (*9655) CARREFOUR Nashti: 18850.72GEL    11/06/26 21:33

--- a/src/TBC Bank-ge_15622/formats/GEL CARREFOUR Nashti GEL.txt
+++ b/src/TBC Bank-ge_15622/formats/GEL CARREFOUR Nashti GEL.txt
@@ -1,0 +1,50 @@
+(\d[\d\s.,]*[.,]\d{2})(\S+)\s+\(\*(\d{4})\)\s+(.+?)\s+(?:Balance:|Nashti:)\s*(-?\d[\d\s.,]*[.,]\d{2})(\S+)\s+(\d{2}\/\d{2}\/\d{2})
+
+-----COLUMNS-----
+outcome;instrument;syncid;payee;balance;acc_instrument;date#dMy
+
+-----EXAMPLE-----
+34.20GEL (*9655) CARREFOUR Nashti: 18850.72GEL    11/06/26 21:33
+
+-----EXAMPLE-----
+15.70GEL (*5364) MOZAIKA Balance: 8256.74GEL    11/06/26 16:52
+
+-----EXAMPLE-----
+14.00GEL
+(*1198)
+Google DramaWave Dram
+Balance: 3610.45GEL
+
+29/07/26 12:29
+
+-----EXAMPLE-----
+1002.60USD
+(*9846)
+AIR ASTANA
+Balance: 3624.66GEL
+
+28/07/26 21:17
+
+-----EXAMPLE-----
+11.50GEL
+(*1198)
+BoltTaxi
+Balance: 6200.62GEL
+
+26/07/26 20:14
+
+-----EXAMPLE-----
+105.67GEL
+(*9846)
+Wildberries
+Balance: 6212.12GEL
+
+26/07/26 18:22
+
+-----EXAMPLE-----
+11.90GEL
+(*1198)
+BoltTaxi
+Balance: 6317.79GEL
+
+26/07/26 17:59


### PR DESCRIPTION
## Summary
- PR #973 merged two previously separate TBC formats (with cashback comment "You've received..." and without it) into one file, using optional capturing groups `(?:...)?` for `balance`/`acc_instrument`/`comment`.
- The Zenmoney mobile parsing engine does not handle optional capturing groups correctly: when such a group doesn't participate in a match, the app sees fewer captured groups than columns and rejects the SMS as an unknown format, even though the regex matches fine under Python/regex101 (confirmed in community chat discussion, tracked as zenmoney/sms-formats#1031).
- This reverts the merge: restores two formats, each with only mandatory capturing groups (no `(...)?` on any capturing group), matching the pattern used before #973.
  - `GEL BoltTaxi Balance GEL You ve received GEL In Er_11671.txt` — SMS with the cashback comment line.
  - `GEL CARREFOUR Nashti GEL.txt` (recreated, no id — the old id from the deleted pre-merge file may no longer be valid) — SMS without the comment line, now also covering the "no space between amount and currency" case reported by users (e.g. `14.00GEL`, `1002.60USD`).

## Test plan
- [x] `python3 scripts/validate.py` passes locally.
- [x] Verified with the actual parser (`sms_format_repository._parse_format_file` + `compile_regex`) that every example in both files matches with the correct field values, and that no example cross-matches the other file's regex.
- [x] No regex in either file contains an optional capturing group.