### PR TITLE
[TBC Bank-ge] fix date order in format Deposit USD PMT Bal GEL

### DIFF
--- a/src/TBC Bank-ge_15622/formats/Deposit USD PMT Bal GEL_11750.txt
+++ b/src/TBC Bank-ge_15622/formats/Deposit USD PMT Bal GEL_11750.txt
@@ -1,7 +1,10 @@
 Deposit:\s+(\d[\d\s.,]*[.,]\d{2})([A-Z]{3})\s+\(\*(\d{4})\)\s+([A-Za-z]+)\s+\$\s+Bal:\s+(\d[\d\s.,]*[.,]\d{2})\s+([A-Z]{3})\s+(\d{2}\/\d{2}\/\d{2})
 
 -----COLUMNS-----
-income;instrument;syncid;payee;balance;acc_instrument;date#Mdy
+income;instrument;syncid;payee;balance;acc_instrument;date#dMy
 
 -----EXAMPLE-----
 Deposit: 470.98USD (*1198) PMT $ Bal: 15258.48 GEL  03/07/26 10:54
+
+-----EXAMPLE-----
+Deposit: 1984.45EUR (*1198) PMT $ Bal: 13146.80 GEL  27/08/26 17:24


### PR DESCRIPTION
## Summary
- The format `src/TBC Bank-ge_15622/formats/Deposit USD PMT Bal GEL_11750.txt` declared `date#Mdy`, while TBC Bank sends this date as `dd/MM/yy`. All 17 other TBC Bank formats use `date#dMy`.
- Real SMS confirm the order: `27/08/26` and `20/08/26` — the first component exceeds 12, so it is the day. Parsed as `Mdy`, such an SMS is rejected, and an ambiguous one like `05/08/26` is silently read as May 8 instead of August 5.
- The original example `03/07/26` is ambiguous under both readings, which is probably how the wrong order slipped in unnoticed. Added a second example with `27/08/26` so the file documents the order on its own.

## Test plan
- [x] `python3 scripts/validate.py` passes locally.
- [x] Both examples match the (unchanged) regex; date group captures `03/07/26` and `27/08/26` respectively.
