### PR TITLE
[Bank of Georgia-ge] create format Deposit USD GE USD Balance USD

### DIFF
--- a/src/Bank of Georgia-ge_15636/formats/Deposit USD GE USD Balance USD.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Deposit USD GE USD Balance USD.txt
@@ -1,7 +1,7 @@
-Deposit:\s+([A-Z]{3})(\d[\d\s.,]*[.,]\d{2})\s+[A-Z0-9]+\*{3}(\d{4})(?:[A-Z]{3})?\s+Balance:\s+([A-Z]{3})(-?\d[\d\s.,]*[.,]\d{2})\s+(\d{2}\.\d{2}\.\d{4})
+Deposit:\s+([A-Z]{3})(\d[\d\s.,]*[.,]\d{2})\s+[A-Z0-9]+\*{3}(\d{4})([A-Z]{3})\s+Balance:\s+(?:[A-Z]{3})(-?\d[\d\s.,]*[.,]\d{2})\s+(\d{2}\.\d{2}\.\d{4})
 
 -----COLUMNS-----
-instrument;income;syncid;acc_instrument;balance;date#dMy
+instrument;income;syncid;acc_instrument;av_balance;date#dMy
 
 -----EXAMPLE-----
 Deposit: USD1,800.00 GE40***0471USD Balance: USD3,778.68 19.08.2026

--- a/src/Bank of Georgia-ge_15636/formats/Deposit USD GE USD Balance USD.txt
+++ b/src/Bank of Georgia-ge_15636/formats/Deposit USD GE USD Balance USD.txt
@@ -1,0 +1,10 @@
+Deposit:\s+([A-Z]{3})(\d[\d\s.,]*[.,]\d{2})\s+[A-Z0-9]+\*{3}(\d{4})(?:[A-Z]{3})?\s+Balance:\s+([A-Z]{3})(-?\d[\d\s.,]*[.,]\d{2})\s+(\d{2}\.\d{2}\.\d{4})
+
+-----COLUMNS-----
+instrument;income;syncid;acc_instrument;balance;date#dMy
+
+-----EXAMPLE-----
+Deposit: USD1,800.00 GE40***0471USD Balance: USD3,778.68 19.08.2026
+
+-----EXAMPLE-----
+Deposit: GEL4,000.00 GE40***0471GEL Balance: USD3,439.09 22.08.2026


### PR DESCRIPTION
## Summary
- Deposits to an account are not recognized when the SMS has no payee line:

```
Deposit: USD1,800.00
GE40***0471USD
Balance: USD3,778.68
19.08.2026
```

- The closest existing format, `Deposit EUR GE EUR minenkov anton Balance GEL_11407.txt`, has a mandatory `(.+?)\s+` group for `payee` between the masked account and `Balance:`. These SMS have nothing there, so the regex does not match. Making that group optional is not an option (optional capturing groups break the mobile parsing engine, see #1031/#1036), hence a separate format.
- Columns: `instrument;income;syncid;acc_instrument;av_balance;date#dMy`. The currency suffix after the masked account is a mandatory capturing group mapped to `acc_instrument`; the currency before the balance is non-capturing. Amounts require cents and the date is `dd.MM.yyyy`.

## Test plan
- [x] `python3 scripts/validate.py` passes locally (so no cross-match in either direction with the other 34 Bank of Georgia formats).
- [x] Verified with `sms_format_repository._parse_format_file` + `compile_regex` that both examples match with the expected field values, and that a third real SMS of the same shape (`USD1,000.00`, balance `12,040.88`) matches too.
- [x] Confirmed none of the existing Bank of Georgia formats matches these SMS before the change.
